### PR TITLE
main plugin fix try 01

### DIFF
--- a/src/plugins/isf/OMNIDOME.fs
+++ b/src/plugins/isf/OMNIDOME.fs
@@ -8,11 +8,11 @@
     "INPUTS":
     [
         {
-            "NAME": "Input Image",
+            "NAME": "image",
             "TYPE": "image"
         },
         {
-            "NAME": "UVW Map",
+            "NAME": "uvw_map",
             "TYPE": "image"
         },
 
@@ -219,7 +219,7 @@ float mapping(out vec2 texCoords)
 #endif
   return -1.0;
 }
-#endif
+//#endif
 
 
 void main()


### PR DESCRIPTION
at line 243 function uvwize(vec3 n) is not declared. uvwResize()???
commenting this line out, the shader gives what seems to be a single pixel sample of the imageInput with the correct alpha extracted from the mask. (n is not used)